### PR TITLE
Feat/preservable

### DIFF
--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp, h } from 'vue'
 import VueSelect from '@/index'
+import NewVueSelect from '@/index2'
 import App from './app.vue' // must be imported after VueSelect
 import router from './router'
 // import IconDown from './components/IconDown.vue'
@@ -19,5 +20,6 @@ const app = createApp(App)
 app.use(router)
 
 app.component('VSelect', VueSelect)
+app.component('NewVueSelect', NewVueSelect)
 
 app.mount('#app')

--- a/demo/src/router.ts
+++ b/demo/src/router.ts
@@ -37,6 +37,11 @@ const routes = [
     name: 'Placeholder',
     component: () => import('./views/Placeholder.vue'),
   },
+  {
+    path: '/preservable',
+    name: 'Preservable',
+    component: () => import('./views/Preservable.vue'),
+  },
   // Fallback route for handling 404s
   {
     path: '/:pathMatch(.*)*',

--- a/demo/src/router.ts
+++ b/demo/src/router.ts
@@ -32,6 +32,11 @@ const routes = [
     name: 'InfiniteScroll',
     component: InfiniteScroll,
   },
+  {
+    path: '/preservable',
+    name: 'Preservable',
+    component: () => import('./views/Preservable.vue'),
+  },
   // Fallback route for handling 404s
   {
     path: '/:pathMatch(.*)*',

--- a/demo/src/router.ts
+++ b/demo/src/router.ts
@@ -33,9 +33,9 @@ const routes = [
     component: InfiniteScroll,
   },
   {
-    path: '/preservable',
-    name: 'Preservable',
-    component: () => import('./views/Preservable.vue'),
+    path: '/placeholder',
+    name: 'Placeholder',
+    component: () => import('./views/Placeholder.vue'),
   },
   // Fallback route for handling 404s
   {

--- a/demo/src/views/Placeholder.vue
+++ b/demo/src/views/Placeholder.vue
@@ -13,8 +13,12 @@ watch(selected, () => {
 <template>
   <div>
     <div class="section">
-      <h2 class="title">Preservable</h2>
-      <v-select v-model="selected" :options="options" />
+      <h2 class="title">Placeholder</h2>
+      <v-select
+        v-model="selected"
+        placeholder="Hello World"
+        :options="options"
+      />
     </div>
   </div>
 </template>

--- a/demo/src/views/Preservable.vue
+++ b/demo/src/views/Preservable.vue
@@ -6,7 +6,7 @@ const selected = ref(null)
 const options = ref(countries)
 
 watch(selected, () => {
-  console.log('preservable watch: ', selected.value)
+  console.log('watch model: ', selected.value)
 })
 </script>
 
@@ -14,7 +14,7 @@ watch(selected, () => {
   <div>
     <div class="section">
       <h2 class="title">Preservable</h2>
-      <v-select preservable v-model="selected" :options="options" />
+      <v-select v-model="selected" :options="options" />
     </div>
   </div>
 </template>

--- a/demo/src/views/Preservable.vue
+++ b/demo/src/views/Preservable.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import countries from '../mocks/countryCodes.js'
+
+const selected = ref(null)
+const options = ref(countries)
+
+watch(selected, () => {
+  console.log('watch model: ', selected.value)
+})
+</script>
+
+<template>
+  <div>
+    <div class="section">
+      <h2 class="title">preservable: false</h2>
+      <p>Users can only select existing options.</p>
+      <v-select v-model="selected" :preservable="false" :options="options" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss"></style>

--- a/demo/src/views/Preservable.vue
+++ b/demo/src/views/Preservable.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import countries from '../mocks/countryCodes.js'
+
+const selected = ref(null)
+const options = ref(countries)
+
+watch(selected, () => {
+  console.log('preservable watch: ', selected.value)
+})
+</script>
+
+<template>
+  <div>
+    <div class="section">
+      <h2 class="title">Preservable</h2>
+      <v-select preservable v-model="selected" :options="options" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss"></style>

--- a/demo/src/views/Test.vue
+++ b/demo/src/views/Test.vue
@@ -1,35 +1,45 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 
-const selected = ref({
-  name: 'Bar',
-  id: 1,
-})
-
-const options = ref([
+const options = [
   {
-    name: 'Foo',
-    id: 0,
+    label: 'foo',
   },
   {
-    name: 'Bar',
-    id: 1,
+    label: 'bar',
   },
-])
+]
+const selected = ref(options[0])
+
+const optionList = ['foo', 'bar']
+const selectedOption = ref(optionList[0])
 </script>
 
 <template>
   <div>
     <div class="section">
-      <h2 class="title">Test</h2>
+      <h2 class="title">Good</h2>
       <v-select
+        :preservable="false"
+        :clearable="false"
         v-model="selected"
         :options="options"
-        :get-option-label="(option: any) => option.name"
       >
-        <template #option="{ code, name }">
+      </v-select>
+
+      <div class="h-5"></div>
+
+      <h2 class="title">NG (fixed)</h2>
+
+      <v-select
+        :preservable="false"
+        :clearable="false"
+        v-model="selectedOption"
+        :options="optionList"
+      >
+        <!-- <template #option="{ code, name }">
           {{ name }} with code: {{ code }}
-        </template>
+        </template> -->
       </v-select>
     </div>
   </div>

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -4,7 +4,13 @@ import { fileURLToPath, URL } from 'url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    vue({
+      script: {
+        defineModel: true,
+      },
+    }),
+  ],
   build: {
     target: 'esnext',
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue3-select",
-  "version": "0.1.1",
+  "version": "0.2.0-alpha.1",
   "description": "A maintained fork of vue-select for Vue 3",
   "author": "Howard Chen <howard.tzw@gmail.com>",
   "homepage": "",

--- a/src/components/NewSelect.vue
+++ b/src/components/NewSelect.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+const modelValue = defineModel()
+
+// const props = withDefaults(defineProps<{}>(), {})
+</script>
+
+<template>
+  <div>
+    <input type="text" v-model="modelValue" />
+  </div>
+</template>
+
+<style lang="scss">
+@import '../css/vue-select.css';
+</style>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -204,9 +204,20 @@ export default {
     // eslint-disable-next-line vue/require-default-prop,vue/require-prop-types
     modelValue: {},
 
+    /**
+     * to display no options description or not
+     */
     showNoOptions: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * To preserve user-entered values in the input field,
+     * even if no matching options are found in the dropdown list.
+     */
+    preservable: {
+      type: Boolean,
+      default: true,
     },
 
     /**
@@ -973,6 +984,20 @@ export default {
 
   // @note watch
   watch: {
+    /**
+     * @feat preservable
+     */
+    isDropdownOpen() {
+      if (!this.preservable) {
+        if (!this.filteredOptions.length && this.search) {
+          this.search = this.search.slice(0, -1)
+        }
+
+        if (!this.isDropdownOpen && this.search) {
+          this.search = null
+        }
+      }
+    },
     /**
      * Maybe reset the value
      * when options change.

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -401,7 +401,7 @@ export default {
       type: Function,
       default(option) {
         if (typeof option === 'object') {
-          if (!option.hasOwnProperty(this.label)) {
+          if (!Object.prototype.hasOwnProperty.call(option, this.label)) {
             return console.warn(
               `[vue-select warn]: Label key "option.${this.label}" does not` +
                 ` exist in options object ${JSON.stringify(option)}.\n` +
@@ -438,7 +438,7 @@ export default {
         }
 
         try {
-          return option.hasOwnProperty('id')
+          return Object.prototype.hasOwnProperty.call(option, 'id')
             ? option.id
             : sortAndStringify(option)
         } catch (e) {
@@ -741,6 +741,9 @@ export default {
      */
     search: {
       get() {
+        if (!this.preservable) {
+          return undefined
+        }
         if (this.modelValue && typeof this.modelValue !== 'string') {
           return this.selectedValue?.[this.label]
         }
@@ -956,6 +959,7 @@ export default {
       const options = this.search?.length
         ? this.filter(optionList, this.search, this)
         : optionList
+
       if (this.taggable && this.search?.length) {
         const createdOption = this.createOption(this.search)
         if (!this.optionExists(createdOption)) {
@@ -1051,6 +1055,7 @@ export default {
     },
   },
 
+  // @note created
   created() {
     this.mutableLoading = this.loading
   },

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -204,11 +204,7 @@ export default {
     // eslint-disable-next-line vue/require-default-prop,vue/require-prop-types
     modelValue: {},
 
-    /**
-     * Extend the functionality of the Select component to preserve user-entered values in the input field,
-     * even if no matching options are found in the dropdown list.
-     */
-    preservable: {
+    showNoOptions: {
       type: Boolean,
       default: false,
     },
@@ -573,18 +569,6 @@ export default {
     },
 
     /**
-     * If search text should clear on blur
-     * @return {Boolean} True when single and clearSearchOnSelect
-     */
-    clearSearchOnBlur: {
-      type: Function,
-      default: function ({ clearSearchOnSelect, multiple }) {
-        if (this.preservable) return false
-        return clearSearchOnSelect && !multiple
-      },
-    },
-
-    /**
      * Disable the dropdown entirely.
      * @type {Boolean}
      */
@@ -752,13 +736,17 @@ export default {
         return this.modelValue
       },
       set(newVal) {
-        if (!newVal && !this.modelValue) {
+        if (!newVal && !this.modelValue && this.selectedValue) {
           return
         }
         this.updateValue(newVal)
       },
     },
     isDropdownOpen() {
+      if (!this.showNoOptions && !this.filteredOptions.length) {
+        return false
+      }
+
       return this.dropdownOpen
     },
     isReducingValues() {
@@ -940,6 +928,7 @@ export default {
     },
 
     /**
+     * @note filteredOptions
      * The currently displayed options, filtered
      * by the search elements value. If tagging
      * true, the search text will be prepended
@@ -1120,6 +1109,7 @@ export default {
     },
 
     /**
+     * @note onAfterSelect
      * Called from this.select after each selection.
      * @param  {Object|String} option
      * @return {void}
@@ -1128,10 +1118,6 @@ export default {
       if (this.closeOnSelect) {
         this.open = !this.open
         this.searchEl.blur()
-      }
-
-      if (this.clearSearchOnSelect) {
-        this.search = ''
       }
     },
 
@@ -1337,19 +1323,17 @@ export default {
     },
 
     /**
+     * @note onSearchBlur
      * Close the dropdown on blur.
      * @emits  {search:blur}
      * @return {void}
      */
     onSearchBlur() {
       this.open = false
+
       if (this.mousedown && !this.searching) {
         this.mousedown = false
       } else {
-        const { clearSearchOnSelect, multiple } = this
-        if (this.clearSearchOnBlur({ clearSearchOnSelect, multiple })) {
-          this.search = ''
-        }
         this.$emit('search:blur')
         return
       }

--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -14,7 +14,7 @@
 
   /* Search Input */
   --vs-search-input-color: inherit;
-  --vs-search-input-placeholder-color: inherit;
+  --vs-search-input-placeholder-color: var(--vs-colors--light);
 
   /* State - No drop */
   --vs-state-no-drop-bg: inherit;

--- a/src/css/modules/search-input.css
+++ b/src/css/modules/search-input.css
@@ -58,10 +58,3 @@
     cursor: pointer;
   }
 }
-
-/* Single, when searching but not loading or open */
-.vs--single.vs--searching:not(.vs--open):not(.vs--loading) {
-  .vs__search {
-    opacity: 0.2;
-  }
-}

--- a/src/index2.js
+++ b/src/index2.js
@@ -1,0 +1,3 @@
+import NewVueSelect from './components/NewSelect.vue'
+
+export default NewVueSelect

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,13 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    vue({
+      script: {
+        defineModel: true,
+      },
+    }),
+  ],
   publicDir: false,
   resolve: {
     alias: {


### PR DESCRIPTION
Extend the functionality of the Select component to preserve user-entered values in the input field, even if no matching options are found in the dropdown list.

If developers want to make user only select existing options, you can add `:preservable="false"` to the select component like the following:

```vue
<v-select v-model="selected" :preservable="false" :options="options" />
```

By default, the component is preservable, it means you can use the select component like a simple input.